### PR TITLE
use pycryptodome instead of pycrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pycrypto
+pycryptodome


### PR DESCRIPTION
pycrypto is outdated, it's vulnerable(https://github.com/pycrypto/pycrypto/issues/285) and not compatible with high version setuptools(https://github.com/pycrypto/pycrypto/issues/327)